### PR TITLE
 Add methods to verify if selector is editable or not

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -166,6 +166,17 @@ BrowseTheWeb.as(actor).checkVisibilityState('mySelector', 'visible');
 BrowseTheWeb.as(actor).checkVisibilityState('mySelector', 'hidden', { hasText: 'myText', subSelector: ['mySubSelector', { hasText: 'anotherText' } ]});
 ```
 
+### checkEditableState(selector: Selector, mode: 'editable' | 'notEditable', options?: SelectorOptions)
+
+Verify if a locator on the page is editable.
+
+```js
+// simple call with just selector
+BrowseTheWeb.as(actor).checkEditableState('mySelector', 'editable');
+// or with options
+BrowseTheWeb.as(actor).checkEditableState('mySelector', 'notEditable', { hasText: 'myText', subSelector: ['mySubSelector', { hasText: 'anotherText' } ]});
+```
+
 ### press(keys: string)
 
 Press the specified key(s) on the keyboard.
@@ -689,6 +700,17 @@ Validates wether an element is enabled. A mode operator must be prepended.
 Element.toBe.enabled('mySelector');
 // or with options
 Element.notToBe.enabled('mySelector', { hasText: 'myText', subSelector: ['mySubSelector', { hasText: 'anotherText' } ]});
+```
+
+### Element.*.editable(selector: Selector, options?: SelectorOptions)
+
+Validates wether an element is editable. A mode operator must be prepended.
+
+```js
+// simple call with just selector
+Element.toBe.editable('mySelector');
+// or with options
+Element.notToBe.editable('mySelector', { hasText: 'myText', subSelector: ['mySubSelector', { hasText: 'anotherText' } ]});
 ```
 
 ## Available Api Questions

--- a/src/web/abilities/BrowseTheWeb.ts
+++ b/src/web/abilities/BrowseTheWeb.ts
@@ -215,6 +215,23 @@ export class BrowseTheWeb extends Ability {
   }
 
   /**
+     * Validate if a locator on the page is editable or not.
+     *
+     * @param {Selector} selector the locator to search for.
+     * @param {string} mode the expected property of the selector that needs to be checked. either 'editable' or 'notEditable'.
+     * @param {SelectorOptions} options (optional) advanced selector lookup options.
+     * @returns {boolean} true if the element is editable/not as expected, false if the timeout was reached.
+     */
+  public async checkEditableState(selector: Selector, mode: 'editable' | 'notEditable', options?: SelectorOptions): Promise<boolean> {
+    if (mode === 'editable') {
+      await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).toBeEditable({ timeout: options?.timeout });
+    } else {
+      await expect(await recursiveLocatorLookup({ page: this.page, selector, options: { ...options, state: 'visible' } })).not.toBeEditable({ timeout: options?.timeout });
+    }
+    return Promise.resolve(true);
+  }
+
+  /**
     * Validate if the given element has the given text or not.
     *
     * @param selector the selector of the element to hover over.

--- a/src/web/questions/Element.ts
+++ b/src/web/questions/Element.ts
@@ -4,10 +4,11 @@ import { BrowseTheWeb } from '../abilities/BrowseTheWeb';
 import { Selector, SelectorOptions } from '../types';
 
 /**
- * Question Class. Get a specified state for a selector like visible or enabled.
+ * Question Class. Get a specified state for selector as following.
+ * { visible, enabled, editable }.
  */
 export class Element extends Question<boolean> {
-  private mode: 'visible' | 'enabled' | 'text' | 'value' = 'visible';
+  private mode: 'visible' | 'enabled' | 'editable' | 'text' | 'value' = 'visible';
 
   // the selector of the element to check.
   private selector: Selector = '';
@@ -55,7 +56,6 @@ export class Element extends Question<boolean> {
           await BrowseTheWeb.as(actor).checkSelectorValue(this.selector, this.payload, this.checkMode === 'toBe' ? 'has' : 'hasNot', this.options),
         ); // if the ability method is not the expected result there will be an exception
       }
-
       throw new Error('Element.value: incompatible payload! Arrays can not be checked.');
     }
     throw new Error('Unknown mode: Element.answeredBy');
@@ -150,6 +150,21 @@ export class Element extends Question<boolean> {
     this.mode = 'value';
     this.selector = selector;
     this.payload = value;
+    this.options = options;
+
+    return this;
+  }
+
+  /**
+  * Verifies if an element is editable.
+  *
+  * @param {Selector} selector the selector
+  * @param {SelectorOptions} options (optional) advanced selector lookup options.
+  * @return {Element} this Element instance
+  */
+  public editable(selector: Selector, options?: SelectorOptions): Element {
+    this.mode = 'editable';
+    this.selector = selector;
     this.options = options;
 
     return this;


### PR DESCRIPTION
### Changes

- Add methods to the `BrowseTheWeb` and `Element` classes to verify if a selector is editable or not