### PR TITLE
Set environment of GITHUB_TOKEN when create a pull request

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,6 +41,8 @@ jobs:
         run: npm run build:docs
 
       - name: Commit changes of documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           hash=$(git rev-parse --short HEAD)
           branch_name="docs-${hash}"


### PR DESCRIPTION
### Changes

- Fix bug of workflow to build documents
    - Set environment of `GITHUB_TOKEN` when create a pull request

### Remarks

<https://docs.github.com/ja/actions/using-workflows/using-github-cli-in-workflows>